### PR TITLE
Correct navbar on changelog page

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -28,11 +28,13 @@
 <div class="navbar">
 	&nbsp;<a href="index.html">home</a>&nbsp;&nbsp;|
 	&nbsp;<a href="faq.html">faq</a>&nbsp;&nbsp;|
+	&nbsp;<a href="news.html">news</a>&nbsp;&nbsp;|
 	&nbsp;<a href="download.html">download</a>&nbsp;&nbsp;|
 	&nbsp;<a href="documentation.html">documentation</a>&nbsp;&nbsp;|
-	&nbsp;<a href="developers.html">developers</a>&nbsp;&nbsp;|
+	&nbsp;<a href="comparison.html">comparison</a>&nbsp;&nbsp;|
 	&nbsp;changelog&nbsp;&nbsp;|
-	&nbsp;<a href="http://xiph.org/flac">more</a>
+	&nbsp;<a href="links.html">links</a>&nbsp;&nbsp;|
+	&nbsp;<a href="developers.html">developers</a>&nbsp;
 </div>
 
 <div class="below_nav"></div>


### PR DESCRIPTION
Current navbar is from the documentation bundled with the release,
which has some differences, amongst others the navbar.